### PR TITLE
Use a timeout when calling urllopen()

### DIFF
--- a/idnits.pyht
+++ b/idnits.pyht
@@ -54,8 +54,11 @@ Content-Type: text/html
             uploadsrc = form["filename"].value
 
         if uploadsrc[:8] == "https://" or uploadsrc[:7] == "http://" or uploadsrc[:6] == "ftp://":
-            import urllib
-            uploadfile = urllib.urlopen(uploadsrc)
+            import urllib2
+            try:
+                uploadfile = urllib2.urlopen(uploadsrc, timeout=20)
+            except:
+                error("404", "Not Found", uploadsrc)
         elif form["filename"].file:
             uploadfile = form["filename"].file
         else:
@@ -65,9 +68,9 @@ Content-Type: text/html
     elif "url" in args:
         #sys.stderr.write("X-Here: 1\n")
         try:
-            import urllib
+            import urllib2
             uploadsrc = args["url"]
-            uploadfile = urllib.urlopen(uploadsrc)
+            uploadfile = urllib2.urlopen(uploadsrc, timeout=20)
         except:
             error("404", "Not Found", uploadsrc)
             sys.exit(1)

--- a/idnits.pyht
+++ b/idnits.pyht
@@ -59,6 +59,7 @@ Content-Type: text/html
                 uploadfile = urllib2.urlopen(uploadsrc, timeout=20)
             except:
                 error("404", "Not Found", uploadsrc)
+                sys.exit(1)
         elif form["filename"].file:
             uploadfile = form["filename"].file
         else:


### PR DESCRIPTION
This switches from the outdated urllib to the less outdated urllib2 and uses the `timeout` parameter for `urlopen()` to avoid hanging indefinitely. 

One code path involving `urlopen()` was treating a failed retrieval as a 404 - this replicates that on the other path which, I believe, will avoid an exception bubbling out of the script. There's room for improvement producing a more accurate error response but this is the low-hanging improvement.

Fixes #1. Untested because I am not set up to run pyht.